### PR TITLE
Minimize the bundle size of TypeScript builds.

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,3 +1,3 @@
 > 1%
 last 2 versions
-not ie <= 8
+not ie <= 10

--- a/build-scripts/rollup.config.js
+++ b/build-scripts/rollup.config.js
@@ -10,7 +10,7 @@ import { terserOptions } from './rollup.terser.config'
 
 process.env.NODE_ENV = 'production'
 
-const distPath = 'test-dist'
+const distPath = 'dist'
 const libraryName = 'vue-easy-lightbox'
 const entryPath = 'src/index.ts'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "es5",
     "module": "esnext",
     "strict": true,
     "jsx": "preserve",


### PR DESCRIPTION
The previous configuration target is `esnext`, which causes tsc compiled source code not to be `ES5` . And Babel import a lot of pollyfill, which causes the bundle size to be too large. 