### PR TITLE
Add alttext for images

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -285,9 +285,9 @@ Props
     </tr>
     <tr>
       <td>imgs</td>
-      <td>String/String[]/ImgObject:{ src: string, title: string }/ImgObject[]</td>
+      <td>String/String[]/ImgObject:{ src: string, title: string, alt: string }/ImgObject[]</td>
       <td>required</td>
-      <td>图片的src字符串或图片对象(地址和标题) { src, title }，传入数组则可以轮播显示</td>
+      <td>图片的src字符串或图片对象(地址/标题/alt) { src, title, alt }，传入数组则可以轮播显示</td>
     </tr>
     <tr>
       <td>index</td>

--- a/README.md
+++ b/README.md
@@ -289,9 +289,9 @@ Props
     </tr>
     <tr>
       <td>imgs</td>
-      <td>String/String[]/ImgObject:{ src: string, title: string }/ImgObject[]</td>
+      <td>String/String[]/ImgObject:{ src: string, title: string, alt: string }/ImgObject[]</td>
       <td>required</td>
-      <td>Image's src / array of src / ImgObject:{ src, title } / array of ImgObject / array of ImgObject.</td>
+      <td>Image's src / array of src / ImgObject:{ src, title, alt } / array of ImgObject / array of ImgObject.</td>
     </tr>
     <tr>
       <td>index</td>

--- a/examples/App.vue
+++ b/examples/App.vue
@@ -10,7 +10,9 @@
           class="pic"
           @click="() => show(idx)"
         >
-          <div v-if="idx === 5">This is error image url.</div>
+          <div v-if="idx === 5">
+            This is error image url.
+          </div>
           <img :src="img.src ? img.src : img" />
         </div>
       </div>
@@ -41,7 +43,8 @@
         imgs: [
           {
             title: "img's url: https://i.loli.net/2018/11/10/5be6852cdb002.jpeg",
-            src: ' https://i.loli.net/2018/11/10/5be6852cdb002.jpeg'
+            src: 'https://i.loli.net/2018/11/10/5be6852cdb002.jpeg',
+            alt: 'Red airplane. You can see an island in the background.'
           },
           {
             title: "There is img's description",

--- a/src/vue-easy-lightbox.vue
+++ b/src/vue-easy-lightbox.vue
@@ -37,6 +37,7 @@
             ref="realImg"
             :class="`${prefixCls}-img`"
             :src="visibleImgSrc"
+            :alt="imgAlt"
             draggable="false"
             @mousedown="handleMouseDown($event)"
             @mouseup="handleMouseUp($event)"
@@ -147,6 +148,7 @@
   interface Img {
     src?: string
     title?: string
+    alt?: string
   }
 
   type IndexChangeAction =
@@ -233,6 +235,9 @@
     }
     get imgTitle() {
       return this.imgList[this.imgIndex]?.title
+    }
+    get imgAlt() {
+      return this.imgList[this.imgIndex]?.alt || ''
     }
     get imgTotal() {
       return this.imgList.length || 0

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,8 @@ import Vue from 'vue'
 
 export interface ImgObject {
   url: string
-  title: string
+  title?: string
+  alt?: string
 }
 
 export declare class VueEasyLightbox extends Vue {


### PR DESCRIPTION
Concerning https://github.com/XiongAmao/vue-easy-lightbox/issues/59

- [x] Add alttext for images: `{ src: String, title: String, alt: String }`
- [x] Fix a typing error (*whitespace in example image src*)
- [x] Fix a linter warning (*break after opening and closing `div`*)